### PR TITLE
Support all project types, fix cron implementation, add "run now" option

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cronshelve/CronExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/cronshelve/CronExecutor.java
@@ -7,14 +7,6 @@ import java.util.logging.Logger;
 
 import hudson.scheduler.CronTab;
 import antlr.ANTLRException;
-import hudson.Extension;
-import hudson.model.AsyncPeriodicWork;
-import hudson.model.TaskListener;
-
-import java.io.IOException;
-import java.util.logging.Logger;
-
-import hudson.scheduler.CronTab;
 /**
  * Responsible for performing periodic shelving of jobs via cron
  */
@@ -51,7 +43,10 @@ public class CronExecutor extends AsyncPeriodicWork {
             	LOGGER.warning("[running] cron daemon");
                 CronTab cronTab = new CronTab(cron);
                 long currentTime = System.currentTimeMillis();
-                if ((cronTab.ceil(currentTime).getTimeInMillis() - currentTime) == 0) {
+                // truncate the times to the minute
+                long nextTime = cronTab.floor(currentTime).getTimeInMillis() / 1000 / 60;
+                currentTime = currentTime / 1000 / 60;
+                if (nextTime == currentTime) {
                 	ShelveExecutor shelveExec = new ShelveExecutor(regex,days,email,excludes,debug);
                 	shelveExec.run();
                 }

--- a/src/main/java/org/jenkinsci/plugins/cronshelve/CronShelveLink.java
+++ b/src/main/java/org/jenkinsci/plugins/cronshelve/CronShelveLink.java
@@ -59,7 +59,8 @@ public class CronShelveLink extends ManagementLink{
     		@QueryParameter("cron") String cron,
     		@QueryParameter("regex") String regex,
     		@QueryParameter("days") int days,
-    		@QueryParameter("excludes") String excludes) throws IOException {
+    		@QueryParameter("excludes") String excludes,
+    		@QueryParameter("runNow") boolean runNow) throws IOException {
       checkPermission(Hudson.ADMINISTER);
       String daysStr = Integer.toString(days);
       if(debug)
@@ -87,6 +88,10 @@ public class CronShelveLink extends ManagementLink{
       cronListener.setRegex(regex);
       cronListener.setDays(days);
       cronListener.setExcludes(excludes);
+      if (enable && runNow) {
+          ShelveExecutor shelveExec = new ShelveExecutor(regex,days,email,excludes,debug);
+          shelveExec.run();
+      }
       return new HttpRedirect("index");
     }
     

--- a/src/main/java/org/jenkinsci/plugins/cronshelve/CronShelveLink.java
+++ b/src/main/java/org/jenkinsci/plugins/cronshelve/CronShelveLink.java
@@ -1,17 +1,13 @@
 package org.jenkinsci.plugins.cronshelve;
 import hudson.Extension;
-import hudson.model.FreeStyleProject;
 import hudson.model.Hudson;
 import hudson.model.ManagementLink;
 import hudson.security.Permission;
-import hudson.util.FormValidation;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.logging.Logger;
 
-import javax.servlet.ServletException;
-
+import jenkins.model.Jenkins;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
@@ -48,7 +44,7 @@ public class CronShelveLink extends ManagementLink{
     }
     
     private void checkPermission(Permission permission) {
-        Hudson.getInstance().checkPermission(permission);
+        Jenkins.getInstance().checkPermission(permission);
     }
     
     

--- a/src/main/java/org/jenkinsci/plugins/cronshelve/CronShelvePluginImp.java
+++ b/src/main/java/org/jenkinsci/plugins/cronshelve/CronShelvePluginImp.java
@@ -100,7 +100,7 @@ public class CronShelvePluginImp extends Plugin{
 			    boolean shelveable = shelver.isShelveable(freeStyleProject);
 		        if(shelveable)
 		        {
-		        	jobs.add(freeStyleProject);
+		        	jobs.add(freeStyleProject.getName());
 		        }
     	     }
   		catch (Exception e) 

--- a/src/main/java/org/jenkinsci/plugins/cronshelve/CronShelvePluginImp.java
+++ b/src/main/java/org/jenkinsci/plugins/cronshelve/CronShelvePluginImp.java
@@ -3,11 +3,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
-import org.kohsuke.stapler.DataBoundSetter;
+import hudson.model.AbstractProject;
+import jenkins.model.Jenkins;
 
 import hudson.Plugin;
-import hudson.model.FreeStyleProject;
-import hudson.model.Hudson;
 /**
  * Responsible for plugin setup and persistence of values in CronShelveLink
  */
@@ -21,7 +20,7 @@ public class CronShelvePluginImp extends Plugin{
 	private int days;
 	private String excludes;
 	private static CronShelvePluginImp instance = null;
-	private ArrayList<FreeStyleProject> regexJobs;
+	private List<String> regexJobs;
   // constructor sets instance
   public CronShelvePluginImp() {
 	    instance = this;
@@ -90,14 +89,14 @@ public class CronShelvePluginImp extends Plugin{
   
   public void setRegexJobs(String regex, int days,boolean email,String excludes,boolean debug)
   {
-	ArrayList<FreeStyleProject> jobs = new ArrayList<FreeStyleProject>();
-	Hudson inst =Hudson.getInstance();
-	List<FreeStyleProject> freeStyleProjects = inst.getItems(FreeStyleProject.class);
+	List<String> jobs = new ArrayList<String>();
+	Jenkins inst = Jenkins.getInstance();
+	List<? extends AbstractProject> projects= inst.getItems(AbstractProject.class);
 	ShelveExecutor shelver = new ShelveExecutor(regex,days,email,excludes,debug);
-      for (FreeStyleProject freeStyleProject : freeStyleProjects) 
+      for (AbstractProject project: projects)
       { 
     	  try{
-			    boolean shelveable = shelver.isShelveable(freeStyleProject);
+			    boolean shelveable = shelver.isShelveable(project);
 		        if(shelveable)
 		        {
 		        	jobs.add(freeStyleProject.getName());
@@ -143,7 +142,7 @@ public class CronShelvePluginImp extends Plugin{
   {
 	  return excludes;
   }
-  public ArrayList<FreeStyleProject> getRegexJobs()
+  public List<String> getRegexJobs()
   {
 	  return regexJobs;
   }

--- a/src/main/java/org/jenkinsci/plugins/cronshelve/ShelveExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/cronshelve/ShelveExecutor.java
@@ -1,13 +1,8 @@
 package org.jenkinsci.plugins.cronshelve;
 import org.jvnet.hudson.plugins.shelveproject.ShelveProjectTask;
 
-import hudson.model.AsyncPeriodicWork;
-//import org.jenkins-ci.plugins.shelveproject.ShelveProjectTask;
-import hudson.model.Queue;
-import hudson.model.Hudson;
 import hudson.model.AbstractProject;
 import hudson.model.Queue.Task;
-import hudson.model.FreeStyleProject;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -120,21 +115,21 @@ public class ShelveExecutor {
 	
 	public void run()
 	{
-		Hudson inst =Hudson.getInstance();
-		List<FreeStyleProject> freeStyleProjects = inst.getItems(FreeStyleProject.class);
-        for (FreeStyleProject freeStyleProject : freeStyleProjects) { 
+		Jenkins inst = Jenkins.getInstance();
+		List<AbstractProject> projects = inst.getItems(AbstractProject.class);
+        for (AbstractProject project : projects) {
         		try{
-        			    boolean shelveable = isShelveable(freeStyleProject);
+        			    boolean shelveable = isShelveable(project);
         			    if(this.debug)
         			    {
         			    	LOGGER.warning("isShelveable: "+Boolean.toString(shelveable));
         			    }
 		            	if(shelveable)
 		            	{
-			            	shelveJob(freeStyleProject);
+			            	shelveJob(project);
 			            	if(this.email)
 			            	{
-			            		Email email = new Email(freeStyleProject,this.days);
+			            		Email email = new Email(project,this.days);
 			            		email.sendOwnerEmail();
 			            	}
 		            	}           

--- a/src/main/resources/org/jenkinsci/plugins/cronshelve/CronShelveLink/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cronshelve/CronShelveLink/index.jelly
@@ -35,6 +35,10 @@
 	                    <f:textbox value="${it.configuration.days}" name="days"/>
 	                </f:entry>
 	                
+	            	<f:optionalBlock title="run now" help="/plugin/cron-shelve/help-runNow.html"
+	            		checked="false" name="runNow" >
+                    </f:optionalBlock>
+
 	               <h4>
 	               	  jobs to be Shelved:
                   </h4>

--- a/src/main/resources/org/jenkinsci/plugins/cronshelve/CronShelveLink/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cronshelve/CronShelveLink/index.jelly
@@ -34,7 +34,7 @@
 	                <f:entry title="Job expiration day" field="days" help="/plugin/cron-shelve/help-expiration.html">
 	                    <f:textbox value="${it.configuration.days}" name="days"/>
 	                </f:entry>
-	                
+
 	            	<f:optionalBlock title="run now" help="/plugin/cron-shelve/help-runNow.html"
 	            		checked="false" name="runNow" >
                     </f:optionalBlock>
@@ -48,7 +48,7 @@
 		                <j:when test="${!shelvedProjectsList.isEmpty()}">
 		                        <ol>
 		                         <j:forEach var="shelvedProject" items="${shelvedProjectsList}">
-                                		<li>${shelvedProject.getName()}</li>
+                                		<li>${shelvedProject}</li>
                             		</j:forEach>
 		                        </ol>
 		                </j:when>

--- a/src/main/webapp/help-regex.html
+++ b/src/main/webapp/help-regex.html
@@ -1,6 +1,6 @@
 <div>
   <p>
-     Use a regular expression to select the freestyle jobs you wish to shelve<br/><br/>
+     Use a regular expression to select the jobs you wish to shelve<br/><br/>
      Example:<br/>
      * jobs starting with test (test.*)<br/>
      * jobs ending with nightly (*.nightly)<br/>  

--- a/src/main/webapp/help-runNow.html
+++ b/src/main/webapp/help-runNow.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Will immediately shelve all matched jobs if enable is also checked. Will always be unchecked when this form is loaded.
+    </p>
+</div>


### PR DESCRIPTION
Support shelving all types of projects.
Fix the cron to check only up to the minute and not to the millisecond.
Add a "run now" checkbox which will immediately shelve all matched jobs.
Only store project names in the XML as storing the project object causes a WARNING and a stack trace in the Jenkins log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/cron-shelve-plugin/3)
<!-- Reviewable:end -->
